### PR TITLE
Open dev-master 5.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,5 +47,10 @@
 		"phpstan": "vendor/phpstan/phpstan/bin/phpstan analyse -c vendor/gamee/php-code-checker-rules/phpstan.neon src --level 7",
 		"phpcs": "vendor/bin/phpcs --standard=vendor/ninjify/coding-standard/ruleset-gamee.xml --extensions=php,phpt --tab-width=4 --ignore=temp -sp src",
 		"phpcsfix": "vendor/bin/phpcbf --standard=vendor/ninjify/coding-standard/ruleset-gamee.xml --extensions=php,phpt --tab-width=4 --ignore=temp -sp src"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "5.0.x-dev"
+		}
 	}
 }


### PR DESCRIPTION
When there is a need for testing new vendor verions and we don't want to use `dev-master`, let's use a branch-alias.