### PR TITLE
fixed generating Api docs

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -200,7 +200,7 @@ class Generator
 
 		foreach ($routes as $route) {
 			if ($route->getSection()) {
-				if ($sections[$route->getSection()] === []) {
+				if ($sections !== [] && $sections[$route->getSection()] === []) {
 					$sections[$route->getSection()] = [];
 				}
 


### PR DESCRIPTION
- bug fix
- BC break? no

API `/api/login?__apiDocuGenerate ` generate PHP error: `Notice Undefined index: Login`

Code:

```php
<?php

declare(strict_types=1);

namespace App\Controllers;

use App\Http\ApiResponse;
use Nette\Application\IResponse;
use Nette\Application\Request;
use Contributte\ApiRouter\ApiRoute;

/**
 * API for logging users in
 * 
 * @ApiRoute(
 *      "/api/login",
 *      methods={
 * 		    "POST"="run"
 *      },
 *      presenter="Login",
 *      section="Login",
 *      format="json"
 * )
 */
final class LoginController extends AbstractController
{
	public function run(Request $request): IResponse
	{
		return new ApiResponse($this->apiResponseFormatter->formatMessage('Hello'));
	}
}
```

